### PR TITLE
Fix: Add Root Privileges Check in bulkuseradd.sh (#2)

### DIFF
--- a/bulkuseradd
+++ b/bulkuseradd
@@ -2,6 +2,12 @@
 
 # bulkuseradd.sh - A professional script to add multiple users in bulk.
 
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root." >&2
+    exit 1
+fi
+
 # Default values
 DEFAULT_SHELL="/bin/bash"
 DEFAULT_PASSWORD="Password123"
@@ -154,4 +160,3 @@ for USER in "${USERS[@]}"; do
 done
 
 echo "Bulk user creation process completed."
-


### PR DESCRIPTION
This pull request addresses issue #2 where the bulkuseradd.sh script did not check if it was being run as root. Without this check, non-root users might execute the script and encounter errors when performing operations that require elevated privileges (like user creation and password setting).

**Changes Introduced:**

Added a root privileges check at the very beginning of the script.
This snippet ensures the script exits immediately if not run as root:
`# Check if running as root`
`
if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root." >&2
    exit 1
fi
`

The check prevents the script from proceeding if the current user does not have the necessary permissions, thereby avoiding later failures.

**Testing:**

- Non-root Execution: Ran the script as a non-root user and confirmed that it prints the error message and exits as expected.
- Root Execution: Ran the script as root to verify that it proceeds with the intended operations.

Fixes:
This PR fixes issue **#2.**